### PR TITLE
Add ansible playbook to setup the Dell servers in RDU2 lab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,3 +191,5 @@ cython_debug/
 # Dependency directories (remove the comment below to include it)
 # vendor/
 
+# iDRAC credentials
+idrac_vars.yaml

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -15,7 +15,14 @@ RUN wget -O /usr/local/bin/yq \
   chmod +x /usr/local/bin/yq && \
   pip3 install setuptools-rust && \
   pip3 install --upgrade pip && \
-  ansible-galaxy collection install -vvvv community.docker community.general && \
+  ansible-galaxy collection install -vvvv community.docker community.general dellemc.openmanage && \
   chmod -R g=u "${HOME}/.ansible/" && \
-  INSTALL_PYTHON3_PKGS="netaddr junos-eznc" && \
-  pip3 install --ignore-installed $INSTALL_PYTHON3_PKGS
+  INSTALL_PYTHON3_PKGS="netaddr junos-eznc wheel" && \
+  pip3 install --ignore-installed $INSTALL_PYTHON3_PKGS && \
+  git clone https://github.com/dell/omsdk.git /tmp/omsdk && \
+  cd /tmp/omsdk && \
+  pip3 install -r requirements-python3x.txt && \
+  sh build.sh 1.2 503 && \
+  cd dist && \
+  pip3 install omsdk-1.2.503-py2.py3-none-any.whl
+

--- a/servers-management/dell/ansible/README.md
+++ b/servers-management/dell/ansible/README.md
@@ -1,0 +1,17 @@
+# Prerequisites
+- Ansible Core >= 2.13.7 and 2.14.1
+- Python >= 3.9.6
+- OpenManage Python Software Development Kit (OMSDK)
+
+The OMSDK version installed with pip prevents the ansible module to work with disk controllers, install manually following instructions below
+
+# Install OMSDK from github:
+
+```
+git clone https://github.com/dell/omsdk.git
+cd omsdk
+pip3 install -r requirements-python3x.txt
+sh build.sh 1.2 503
+cd dist
+pip install omsdk-1.2.503-py2.py3-none-any.whl
+```

--- a/servers-management/dell/ansible/dell_setup.yaml
+++ b/servers-management/dell/ansible/dell_setup.yaml
@@ -1,0 +1,138 @@
+---
+- hosts: idrac
+  connection: local
+  name: Dell Server Management
+  gather_facts: False
+  vars_files:
+  - idrac_vars.yaml
+
+  tasks:
+
+  - name: Reset BIOS attributes to default settings, parallel execution
+    dellemc.openmanage.idrac_bios:
+      idrac_ip: "{{ item }}"
+      idrac_user: "{{ idrac_user }}"
+      idrac_password: "{{ idrac_password }}"
+      validate_certs: False
+      reset_bios: yes
+    with_items: "{{ groups['idrac'] }}"
+    register: _create_instances
+    async: 600  # Maximum runtime in seconds. Adjust as needed.
+    poll: 0  # Fire and continue (never poll)
+    tags:
+      - reset_bios
+
+  - name: Wait for BIOS reset jobs to finish
+    async_status:
+      jid: "{{ item.ansible_job_id }}"
+    register: _jobs
+    until: _jobs.finished
+    delay: 120  # Check every 120 seconds. Adjust as you like.
+    retries: 10  # Retry up to 10 times. Adjust as needed.
+    with_items: "{{ _create_instances.results }}"
+
+  - name: Enable PXE 1 and 2, Disable PXE 3 and 4
+    dellemc.openmanage.idrac_bios:
+        idrac_ip: "{{ item }}"
+        idrac_user: "{{ idrac_user }}"
+        idrac_password: "{{ idrac_password }}"
+        validate_certs: False
+        attributes:
+          PxeDev1EnDis: "Enabled"
+          PxeDev2EnDis: "Enabled"
+          PxeDev3EnDis: "Disabled"
+          PxeDev4EnDis: "Disabled"
+    with_items: "{{ groups['idrac'] }}"
+    tags: 
+      - pxeconfig_enable_devices
+
+  - name: Configure PXE Device 1 to boot from Integrated Nic 1 Port 2 Partition 1
+    dellemc.openmanage.idrac_bios:
+        idrac_ip: "{{ item }}"
+        idrac_user: "{{ idrac_user }}"
+        idrac_password: "{{ idrac_password }}"
+        validate_certs: False
+        attributes:
+          PxeDev1Interface: "{{ nic_baremetal }}" # ref: https://issues.redhat.com/browse/OCPQE-14115
+          PxeDev1Protocol: "IPv4"
+          PxeDev1VlanEnDis: "Disabled"
+    with_items: "{{ groups['idrac'] }}"
+    tags: 
+      - pxeconfig_dev1_baremetal
+
+  - name: Configure PXE Device 2 to PXE boot from Integrated Nic 1 Port 3 Partition 1
+    dellemc.openmanage.idrac_bios:
+        idrac_ip: "{{ item }}"
+        idrac_user: "{{ idrac_user }}"
+        idrac_password: "{{ idrac_password }}"
+        validate_certs: False
+        attributes:
+          PxeDev2Interface: "{{ nic_provisioning }}" # ref: https://issues.redhat.com/browse/OCPQE-14115
+          PxeDev2Protocol: "IPv4"
+          PxeDev2VlanEnDis: "Disabled"
+    with_items: "{{ groups['idrac'] }}"
+    tags: 
+      - pxeconfig_dev2_provisioning
+
+
+
+  - name: Configure Bios Generic Attributes # ref: https://issues.redhat.com/browse/OCPQE-14115
+    # Boot mode: UEFI
+    # TPM off
+    # Performance hardware profile
+    # Virtualization technology enabled
+    # SR-IOV enabled
+    dellemc.openmanage.idrac_bios:
+        idrac_ip: "{{ item }}"
+        idrac_user: "{{ idrac_user }}"
+        idrac_password: "{{ idrac_password }}"
+        validate_certs: False
+        attributes:
+          BootMode: "Uefi"
+          TpmSecurity: "Off"
+          SysProfile: "PerfOptimized"
+          ProcVirtualization: "Enabled"
+          SriovGlobalEnable: "Enabled"
+    with_items: "{{ groups['idrac'] }}"
+    tags: 
+      - bios_config
+
+  - name: Configure Boot Sources
+    dellemc.openmanage.idrac_bios:
+        idrac_ip: "{{ item }}"
+        idrac_user: "{{ idrac_user }}"
+        idrac_password: "{{ idrac_password }}"
+        validate_certs: False   
+        boot_sources:
+          - Name: "NIC.PxeDevice.1-1"
+            Enabled: true
+            Index: 0
+          - Name: "NIC.PxeDevice.2-1"
+            Enabled: true
+            Index: 1
+    with_items: "{{ groups['idrac'] }}"
+    tags: 
+      - boot_sources
+
+  - name: Reset disk configuration and re-create virtual drives
+    dellemc.openmanage.dellemc_idrac_storage_volume:
+      idrac_ip: "{{ item }}"
+      idrac_user: "{{ idrac_user }}"
+      idrac_password: "{{ idrac_password }}"
+      validate_certs: False
+      raid_reset_config: "True"
+      state: "create"
+      controller_id: "RAID.Slot.6-1"
+      volumes:
+        - name: "Virtual HDD"
+          drives:
+            id: ["Disk.Bay.0:Enclosure.Internal.0-1:RAID.Slot.6-1"]
+        - name: "Virtual SSD 1"
+          drives:
+            id: ["Disk.Bay.14:Enclosure.Internal.0-1:RAID.Slot.6-1"]
+        - name: "Virtual SSD 2"
+          drives:
+            id: ["Disk.Bay.15:Enclosure.Internal.0-1:RAID.Slot.6-1"]
+    with_items: "{{ groups['idrac'] }}"
+    tags: 
+      - disks_config

--- a/servers-management/dell/ansible/idrac_vars.example.yaml
+++ b/servers-management/dell/ansible/idrac_vars.example.yaml
@@ -1,0 +1,3 @@
+---
+idrac_user: "idrac_user"
+idrac_password: "idrac_password"

--- a/servers-management/dell/ansible/inventory.yaml
+++ b/servers-management/dell/ansible/inventory.yaml
@@ -1,0 +1,17 @@
+idrac:
+  hosts:
+      openshift-qe-047-drac.mgmt.arm.eng.rdu2.redhat.com:
+      openshift-qe-048-drac.mgmt.arm.eng.rdu2.redhat.com:
+      openshift-qe-049-drac.mgmt.arm.eng.rdu2.redhat.com:
+      openshift-qe-050-drac.mgmt.arm.eng.rdu2.redhat.com:
+      openshift-qe-051-drac.mgmt.arm.eng.rdu2.redhat.com:
+      openshift-qe-052-drac.mgmt.arm.eng.rdu2.redhat.com:
+      openshift-qe-053-drac.mgmt.arm.eng.rdu2.redhat.com:
+      openshift-qe-054-drac.mgmt.arm.eng.rdu2.redhat.com:
+      openshift-qe-055-drac.mgmt.arm.eng.rdu2.redhat.com:
+      openshift-qe-056-drac.mgmt.arm.eng.rdu2.redhat.com:
+      openshift-qe-057-drac.mgmt.arm.eng.rdu2.redhat.com:
+      openshift-qe-058-drac.mgmt.arm.eng.rdu2.redhat.com:
+  vars:
+    nic_baremetal: "NIC.Integrated.1-2-1" # ref: https://issues.redhat.com/browse/OCPQE-14115
+    nic_provisioning: "NIC.Integrated.1-3-1"


### PR DESCRIPTION
Ansible playbook to orchestrate the setup of the Dell Servers located at RDU2 and managed by the CI for testing OCP so that their configuration is kept consistent with the requirements for testing.

Implements [OCPQE-14115](https://issues.redhat.com//browse/OCPQE-14115)

