### PR TITLE
OCPQE-15781: Adding bind9.service

### DIFF
--- a/images/bind9/Dockerfile
+++ b/images/bind9/Dockerfile
@@ -1,0 +1,11 @@
+FROM quay.io/centos/centos:stream9
+
+RUN dnf -y update && \
+    dnf -y install bind bind-utils && \
+    dnf clean all
+
+EXPOSE 53/udp 53/tcp
+
+COPY root/ / 
+
+CMD ["/usr/sbin/named", "-g", "-c", "/etc/named.conf", "-u", "named"]

--- a/images/bind9/root/etc/bind/named.conf.default-zones
+++ b/images/bind9/root/etc/bind/named.conf.default-zones
@@ -1,0 +1,28 @@
+// prime the server with knowledge of the root servers
+zone "." {
+	type hint;
+	file "/usr/share/dns/root.hints";
+};
+
+// be authoritative for the localhost forward and reverse zones, and for
+// broadcast zones as per RFC 1912
+
+zone "localhost" {
+	type master;
+	file "/etc/bind/db.local";
+};
+
+zone "127.in-addr.arpa" {
+	type master;
+	file "/etc/bind/db.127";
+};
+
+zone "0.in-addr.arpa" {
+	type master;
+	file "/etc/bind/db.0";
+};
+
+zone "255.in-addr.arpa" {
+	type master;
+	file "/etc/bind/db.255";
+};

--- a/images/bind9/root/etc/bind/named.conf.options
+++ b/images/bind9/root/etc/bind/named.conf.options
@@ -1,0 +1,59 @@
+//
+// named.conf
+//
+// Provided by Red Hat bind package to configure the ISC BIND named(8) DNS
+// server as a caching only nameserver (as a localhost DNS resolver only).
+//
+// See /usr/share/doc/bind*/sample/ for example named configuration files.
+//
+
+options {
+	listen-on port 53 { any; };
+	listen-on-v6 port 53 { any; };
+	directory 	"/var/named";
+	dump-file 	"/var/named/data/cache_dump.db";
+	statistics-file "/var/named/data/named_stats.txt";
+	memstatistics-file "/var/named/data/named_mem_stats.txt";
+	secroots-file	"/var/named/data/named.secroots";
+	recursing-file	"/var/named/data/named.recursing";
+	allow-query     { any; };
+	include "/etc/bind/named.conf.deployment_options";
+
+	/*
+	 - If you are building an AUTHORITATIVE DNS server, do NOT enable recursion.
+	 - If you are building a RECURSIVE (caching) DNS server, you need to enable
+	   recursion.
+	 - If your recursive DNS server has a public IP address, you MUST enable access
+	   control to limit queries to your legitimate users. Failing to do so will
+	   cause your server to become part of large scale DNS amplification
+	   attacks. Implementing BCP38 within your network would greatly
+	   reduce such attack surface
+	*/
+	recursion yes;
+
+	dnssec-validation yes;
+
+	managed-keys-directory "/var/named/dynamic";
+	geoip-directory "/usr/share/GeoIP";
+
+	pid-file "/run/named/named.pid";
+	session-keyfile "/run/named/session.key";
+
+	/* https://fedoraproject.org/wiki/Changes/CryptoPolicy */
+	include "/etc/crypto-policies/back-ends/bind.config";
+};
+
+logging {
+        channel default_debug {
+                file "data/named.run";
+                severity dynamic;
+        };
+};
+
+zone "." IN {
+	type hint;
+	file "named.ca";
+};
+
+include "/etc/named.rfc1912.zones";
+include "/etc/named.root.key";

--- a/images/bind9/root/etc/named.conf
+++ b/images/bind9/root/etc/named.conf
@@ -1,0 +1,11 @@
+// This is the primary configuration file for the BIND DNS server named.
+//
+// Please read /usr/share/doc/bind9/README.Debian.gz for information on the
+// structure of BIND configuration files in Debian, *BEFORE* you customize
+// this configuration file.
+//
+// If you are just adding zones, please do that in /etc/bind/named.conf.local
+
+include "/etc/bind/named.conf.options";
+include "/etc/bind/named.conf.local";
+include "/etc/bind/named.conf.default-zones";

--- a/images/fcos-bastion-image/root/usr/lib/systemd/system-preset/98-bastion.preset
+++ b/images/fcos-bastion-image/root/usr/lib/systemd/system-preset/98-bastion.preset
@@ -2,3 +2,4 @@ enable squid-proxy.service
 enable poc-registry@registry5000.service
 enable poc-registry@registry6001.service
 enable poc-registry@registry6002.service
+enable bind9.service

--- a/images/fcos-bastion-image/root/usr/lib/systemd/system/bind9.service
+++ b/images/fcos-bastion-image/root/usr/lib/systemd/system/bind9.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Creates the bind9 name server service
+Wants=network-online.target
+After=network-online.target
+RequiresMountsFor=%t/containers
+
+[Service]
+Environment=PODMAN_SYSTEMD_UNIT=%n
+Restart=on-failure
+TimeoutStopSec=70
+ExecStartPre=/bin/rm -f %t/%n.ctr-id
+ExecStartPre=/bin/mkdir -p /opt/bind9 /opt/bind9_zones
+ExecStartPre=/bin/touch /opt/bind9/named.conf.local /opt/bind9/named.conf.deployment_options
+ExecStartPre=/bin/bash -c '[ -f /opt/bind9/rndc.key ] || /usr/bin/podman run --rm --name bind9-keygen -v /opt/bind9:/tmp/bind9:Z -u root --entrypoint=/bin/bash registry.ci.openshift.org/ci/bmqe-bind9:latest -c "rndc-confgen -a -c /tmp/bind9/rndc.key && chown named:named /tmp/bind9/rndc.key && chmod 600 /tmp/bind9/rndc.key"'
+ExecStart=/usr/bin/podman run --rm -d -p 53:53/udp -p 53:53/tcp --name bind9 -v /opt/bind9_zones:/var/lib/bind:Z -v /opt/bind9/named.conf.local:/etc/bind/named.conf.local:Z -v /opt/bind9/rndc.key:/etc/rndc.key:Z -v /opt/bind9/named.conf.deployment_options:/etc/bind/named.conf.deployment_options:Z registry.ci.openshift.org/ci/bmqe-bind9:latest
+ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
+ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
+Type=one-shot
+RemainAfterExit=yes
+KillMode=none
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
This code expects the following files:
- /opt/bind9/named.conf.local
- /opt/bind9/named.conf.deployment_options
- zones-specific files (as reported in the /opt/bind9/named.conf.local file)


to be provided externally