### PR TITLE
Update Containerfile

### DIFF
--- a/images/fcos-base-image/Containerfile
+++ b/images/fcos-base-image/Containerfile
@@ -13,7 +13,8 @@ RUN set -x; arch=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/'); cat /etc/
     && ostree container commit
 
 # Replacing nfs-utils-coreos with nfs-utils as some required packages (e.g., libvirt) depend on it: see coreos/fedora-coreos-tracker#572
-RUN rpm-ostree uninstall nfs-utils-coreos && rpm-ostree install nfs-utils && ostree container commit
+# Also, installing nfs-utils will leave content in /var. `rm -rf /var/*` is a workaround until the packages are fixed.
+RUN rpm-ostree uninstall nfs-utils-coreos && rpm-ostree install nfs-utils && rm -rf /var/* && ostree container commit
 
 RUN set -x; PACKAGES_INSTALL="bridge-utils conntrack-tools curl fping iftop iputils iproute mtr nethogs socat"; \
     rpm-ostree install $PACKAGES_INSTALL && ostree container commit

--- a/images/fcos-base-image/Containerfile
+++ b/images/fcos-base-image/Containerfile
@@ -15,7 +15,7 @@ RUN set -x; arch=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/'); cat /etc/
 RUN set -x; PACKAGES_INSTALL="bridge-utils conntrack-tools curl fping iftop iputils iproute mtr nethogs socat"; \
     rpm-ostree install $PACKAGES_INSTALL && ostree container commit
 
-RUN set -x; PACKAGES_INSTALL="chrony targetd targetcli"; \
+RUN set -x; PACKAGES_INSTALL="chrony targetcli"; \
     rpm-ostree install $PACKAGES_INSTALL && rm -rf /var/* && ostree container commit
 
 RUN set -x; PACKAGES_INSTALL="net-tools bind-utils iperf iperf3 iputils mtr ethtool tftp wget ipmitool"; \

--- a/images/fcos-base-image/Containerfile
+++ b/images/fcos-base-image/Containerfile
@@ -12,6 +12,9 @@ RUN set -x; arch=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/'); cat /etc/
         https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm \
     && ostree container commit
 
+# Replacing nfs-utils-coreos with nfs-utils as some required packages (e.g., libvirt) depend on it: see coreos/fedora-coreos-tracker#572
+RUN rpm-ostree uninstall nfs-utils-coreos && rpm-ostree install nfs-utils && ostree container commit
+
 RUN set -x; PACKAGES_INSTALL="bridge-utils conntrack-tools curl fping iftop iputils iproute mtr nethogs socat"; \
     rpm-ostree install $PACKAGES_INSTALL && ostree container commit
 


### PR DESCRIPTION
nfs-utils-coreos conflicts with nfs-utils, dependency of targetd. We will run iscsi as part of a container so no need to install it here. 

Refers coreos/fedora-coreos-tracker#572