### PR TITLE
OCPQE-16616: Adding missing tang.service enabled preset

### DIFF
--- a/images/fcos-bastion-image/root/usr/lib/systemd/system-preset/98-bastion.preset
+++ b/images/fcos-bastion-image/root/usr/lib/systemd/system-preset/98-bastion.preset
@@ -6,3 +6,4 @@ enable nginx.service
 enable bind9.service
 enable fcos-download.timer
 enable dhcp.service
+enable tang.service


### PR DESCRIPTION
Adding missing `tang.service` preset within `images/fcos-bastion-image/root/usr/lib/systemd/system-preset/98-bastion.preset` to enable the service by default.