### PR TITLE
OCPQE-18431: Minor fixes

### DIFF
--- a/images/fcos-base-image/Containerfile
+++ b/images/fcos-base-image/Containerfile
@@ -17,7 +17,7 @@ RUN set -x; PACKAGES_INSTALL="bridge-utils conntrack-tools curl fping iftop iput
                               htop ncdu procps strace iotop subversion git git-lfs gnupg2 lldpd openssl openvpn rsync tcpdump \
                               nmap nmap-ncat krb5-workstation qemu-kvm qemu-user-static libvirt virt-manager virt-install \
                               sudo screen telnet unzip util-linux-user ignition  zsh nmap-ncat socat python3-pip man \
-                              skopeo jq vim neovim inotify-tools firewall-config openvswitch NetworkManager-ovs"; \
+                              skopeo jq vim neovim inotify-tools firewall-config openvswitch NetworkManager-ovs tree"; \
     rpm-ostree install $PACKAGES_INSTALL \
     && ln -s /usr/bin/ld.bfd /usr/bin/ld \
     && ln -s /usr/sbin/ovs-vswitchd.dpdk /usr/sbin/ovs-vswitchd \

--- a/images/fcos-base-image/Containerfile
+++ b/images/fcos-base-image/Containerfile
@@ -5,7 +5,7 @@ ENTRYPOINT ["/bin/bash"]
 RUN set -x; arch=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/'); cat /etc/os-release \
     && rpm-ostree install \
         https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm \
-        https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm \
+        #https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm \
     && ostree container commit
 
 # Replacing nfs-utils-coreos with nfs-utils as some required packages (e.g., libvirt) depend on it: see coreos/fedora-coreos-tracker#572

--- a/images/fcos-bastion-image/root/usr/bin/gen_registry_file.sh
+++ b/images/fcos-bastion-image/root/usr/bin/gen_registry_file.sh
@@ -14,6 +14,8 @@ reg_key_file="/opt/registry-common/domain.key"
 reg_passwd_file="/opt/registry-common/htpasswd"
 
 mkdir -p "/opt/registry-${PORT}/"
+# Ensure the file exists (it needs to be filled by ignition)
+touch "/opt/registry-${PORT}/env"
 
 ## GENERATE REGISTRY CONFIGY.YAML FILE
 cat > "/opt/registry-${PORT}/config.yaml" << EOF

--- a/images/fcos-bastion-image/root/usr/lib/systemd/system/registry@.service
+++ b/images/fcos-bastion-image/root/usr/lib/systemd/system/registry@.service
@@ -17,6 +17,7 @@ ExecStart=/usr/bin/podman run --name registry-${PORT} \
             -v /opt/registry-${PORT}/auth:/auth:Z \
             -v /opt/registry-${PORT}/certs:/certs:Z \
             -v /opt/registry-${PORT}/config.yaml:/etc/docker/registry/config.yml:Z \
+            --env-file /opt/registry-${PORT}/env \
             quay.io/libpod/registry:2.8.2
 ExecStop=/usr/bin/podman stop --ignore registry-${PORT}
 ExecStopPost=/usr/bin/podman rm -f --ignore registry-${PORT}

--- a/images/fcos-bastion-image/root/usr/share/bastion_services/ignitions/wipe_disks.bu
+++ b/images/fcos-bastion-image/root/usr/share/bastion_services/ignitions/wipe_disks.bu
@@ -18,8 +18,8 @@ systemd:
         Wants=network-online.target
         [Service]
         Type=oneshot
-        ExecStart=bash -c 'for i in $(lsblk -I8 -nd --output name); do dd if=/dev/zero of=/dev/$i bs=1M count=16; done'
-        ExecStart=bash -c '/usr/sbin/efibootmgr -v | sed -nE "s|^Boot([0-9A-Fa-f]{4}).*HD\(.*$|\1|gp" | xargs -I% /usr/sbin/efibootmgr --delete-bootnum --bootnum %'
+        ExecStartPre=-bash -c 'for i in $(lsblk -I8,259 -nd --output name); do wipefs -a /dev/$i; done'
+        ExecStartPre=-bash -c '/usr/sbin/efibootmgr -v | sed -nE "s|^Boot([0-9A-Fa-f]{4}).*HD\(.*$|\1|gp" | xargs -I% /usr/sbin/efibootmgr --delete-bootnum --bootnum %'
         ExecStart=/usr/bin/systemctl --no-block poweroff
         StandardOutput=kmsg+console
         StandardError=kmsg+console


### PR DESCRIPTION
- The registries need an env file to provide credentials for the registry mirroring config
- The wipe-fs unit should consider SSDs too. Moreover, we'd allow it to fail to avoid the hosts getting stuck on failures
- Install `tree`
- Disables rpmfusion-nonfree as (1) we don't use any package from that repo, (2) is undergoing a failure at the time of writing due to some updates of the content and the calculation of the checksums.

Related to [OCPQE-18431](https://issues.redhat.com//browse/OCPQE-18431)