### PR TITLE
OCPQE-18500: use dhcp-hostsdir=<path> in dnsmasq for dynamic updates

### DIFF
--- a/images/fcos-bastion-image/root/usr/bin/dhcp-init.sh
+++ b/images/fcos-bastion-image/root/usr/bin/dhcp-init.sh
@@ -2,7 +2,8 @@
 
 set -x
 
-mkdir -p "${PODMAN_DNSMASQ_BASEDIR}"/{etc,tftpboot,misc} /var/opt/{ignitions,html}
+mkdir -p "${PODMAN_DNSMASQ_BASEDIR}"/{etc,tftpboot,misc,hosts/hostsdir,hosts/optsdir} \
+ /var/opt/{ignitions,html}
 ign=/var/opt/ignitions
 cp "${LOCAL_PATH}"/dhcp/dnsmasq.conf "${PODMAN_DNSMASQ_BASEDIR}"/etc/
 if [ -f "${PODMAN_DNSMASQ_BASEDIR}"/dnsmasq.hosts.conf ]; then

--- a/images/fcos-bastion-image/root/usr/lib/systemd/system/dhcp.service
+++ b/images/fcos-bastion-image/root/usr/lib/systemd/system/dhcp.service
@@ -14,6 +14,7 @@ ExecStart=/usr/bin/podman run --name dhcp \
             --network host --cap-add NET_ADMIN --cap-add NET_RAW \
             -v "${PODMAN_DNSMASQ_BASEDIR}/etc:/etc/dnsmasq.d:Z" \
             -v "${PODMAN_DNSMASQ_BASEDIR}/tftpboot:/var/lib/tftpboot:Z" \
+            -v "${PODMAN_DNSMASQ_BASEDIR}/hosts:/var/lib/hosts:Z" \
             -v "${PODMAN_DNSMASQ_BASEDIR}/misc:/var/lib/misc:Z" \
             ${PODMAN_DNSMASQ_IMAGE}
 ExecStop=/usr/bin/podman stop --ignore dhcp

--- a/images/fcos-bastion-image/root/usr/share/bastion_services/dhcp/dnsmasq.conf
+++ b/images/fcos-bastion-image/root/usr/share/bastion_services/dhcp/dnsmasq.conf
@@ -27,6 +27,8 @@ dhcp-match=set:efi_arm,option:client-arch,11
 dhcp-boot=tag:efi,grubx64.efi
 dhcp-boot=tag:efi_arm,grubaa64.efi
 
+dhcp-hostsdir=/var/lib/hosts/hostsdir
+dhcp-optsdir=/var/lib/hosts/optsdir
 expand-hosts
 # Listen on this specific port instead of the standard DNS port
 # (53). Setting this to zero completely disables DNS function,
@@ -565,7 +567,7 @@ bind-interfaces
 # The DHCP server needs somewhere on disk to keep its lease database.
 # This defaults to a sane location, but if you want to change it, use
 # the line below.
-#dhcp-leasefile=/var/lib/misc/dnsmasq.leases
+dhcp-leasefile=/var/lib/misc/dnsmasq.leases
 
 # Set the DHCP server to authoritative mode. In this mode it will barge in
 # and take over the lease for any client which broadcasts on the network,


### PR DESCRIPTION
Use dhcp-hostsdir and dhcp-optsdir

These options help to avoid dnsmasq restarts by dynamically adding new
entries and changes. It only needs a SIGHUP when entries are deleted.

Enabled dnsmasq.leases to see the current active leases if needed while
debugging. The SIGHUP does not update this file.

Tested the options.
1. set the mac to ip address 192.168.123.55
2. Requested IP and received address 192.168.123.55 on a container
2. Deleted container, updated IP address to 192.168.123.67 in the hostsdir file
3. Started a new container
4. Sent a SIGHUP to dnsmasq process
5. Requested for IP and received IP 192.168.123.67 for the same mac
```
# head -20 /var/opt/dnsmasq/etc/dnsmasq.conf         
interface=br-int

dhcp-hostsdir=/var/lib/hosts/hostsdir
dhcp-optsdir=/var/lib/hosts/optsdir
# The subnet mask sent to the clients is /22, to ease the allocation of static VIPs:
# The allowed range is 192.168.80.1--192.168.83.254, where:
# 192.168.80.1 - 192.168.80.254 are reserved for generic use
# 192.168.81.1 - 192.168.81.254 are reserved for API VIPs
# 192.168.82.1 - 192.168.82.254 are reserved for Ingress VIPs
# 192.168.83.1 - 192.168.83.254 are reserved for nodes static leases
dhcp-range=192.168.123.50,192.168.123.75,6h
dhcp-option=option:netmask,255.255.255.0

enable-ra
dhcp-range=fd99:2222:3456::50,fd99:2222:3456::199,6h

dhcp-option=option:router,192.168.123.1
dhcp-option=option:dns-server,192.168.123.1
dhcp-option=option:ntp-server,192.168.123.1

# cat /var/opt/dnsmasq/hosts/hostsdir/stvcluster1-host
ce:39:ba:89:b4:09,192.168.123.67,set:stvcluster1,infinite

# cat /var/opt/dnsmasq/hosts/optsdir/stvcluster1-opts 
# DO NOT EDIT; BEGIN stvcluster1
dhcp-option-force=tag:stvcluster1,15,stvcluster1.qe.arm.openshift.com
dhcp-option-force=tag:stvcluster1,119,stvcluster1.qe.arm.openshit.com
# DO NOT EDIT; END stvcluster1

# nsenter -m -u -n -i -p -t "$(podman inspect -f '{{ .State.Pid }}' "feddhcp1")" /sbin/dhclient -v -pf "/var/run/dhclient.eth1.pid" -lf "/var/lib/dhclient/dhclient.eth1.lease" "eth1"
Internet Systems Consortium DHCP Client 4.4.3-P1
Copyright 2004-2022 Internet Systems Consortium.
All rights reserved.
For info, please visit https://www.isc.org/software/dhcp/

Listening on LPF/eth1/ce:39:ba:89:b4:09
Sending on   LPF/eth1/ce:39:ba:89:b4:09
Sending on   Socket/fallback
DHCPDISCOVER on eth1 to 255.255.255.255 port 67 interval 8 (xid=0x3d27f72e)
DHCPOFFER of 192.168.123.67 from 192.168.123.1
DHCPREQUEST for 192.168.123.67 on eth1 to 255.255.255.255 port 67 (xid=0x3d27f72e)
DHCPACK of 192.168.123.67 from 192.168.123.1 (xid=0x3d27f72e)
System has not been booted with systemd as init system (PID 1). Can't operate.
Failed to connect to bus: Host is down
bound to 192.168.123.67 -- renewal in 2147483646 seconds.

# kill -HUP "$(podman inspect -f '{{ .State.Pid }}' "dhcp")"

# podman logs -f dhcp
dnsmasq: started, version 2.85 DNS disabled
dnsmasq: compile time options: IPv6 GNU-getopt DBus no-UBus no-i18n IDN2 DHCP DHCPv6 no-Lua TFTP no-conntrack ipset auth cryptohash DNSSEC loop-detect inotify dumpfile
dnsmasq-dhcp: DHCP, IP range 192.168.123.50 -- 192.168.123.75, lease time 6h
dnsmasq-dhcp: DHCPv6, IP range fd99:2222:3456::50 -- fd99:2222:3456::199, lease time 6h
dnsmasq-dhcp: router advertisement on fd99:2222:3456::
dnsmasq-dhcp: IPv6 router advertisement enabled
dnsmasq-dhcp: DHCP, sockets bound exclusively to interface br-int
dnsmasq-tftp: TFTP root is /var/lib/tftpboot  
dnsmasq-dhcp: read /var/lib/hosts/optsdir/stvcluster1-opts
dnsmasq-dhcp: read /var/lib/hosts/hostsdir/stvcluster1-host
dnsmasq-dhcp: DHCPDISCOVER(br-int) ce:39:ba:89:b4:09 
dnsmasq-dhcp: DHCPOFFER(br-int) 192.168.123.55 ce:39:ba:89:b4:09 
dnsmasq-dhcp: DHCPREQUEST(br-int) 192.168.123.55 ce:39:ba:89:b4:09 
dnsmasq-dhcp: DHCPACK(br-int) 192.168.123.55 ce:39:ba:89:b4:09 7a7a063ff209
dnsmasq: inotify, new or changed file /var/lib/hosts/hostsdir/4913
dnsmasq-dhcp: read /var/lib/hosts/hostsdir/4913
dnsmasq: inotify, new or changed file /var/lib/hosts/hostsdir/stvcluster1-host
dnsmasq-dhcp: read /var/lib/hosts/hostsdir/stvcluster1-host
dnsmasq-dhcp: read /var/lib/hosts/optsdir/stvcluster1-opts
dnsmasq-dhcp: read /var/lib/hosts/hostsdir/stvcluster1-host
dnsmasq-dhcp: DHCPDISCOVER(br-int) ce:39:ba:89:b4:09 
dnsmasq-dhcp: DHCPOFFER(br-int) 192.168.123.67 ce:39:ba:89:b4:09 
dnsmasq-dhcp: DHCPREQUEST(br-int) 192.168.123.67 ce:39:ba:89:b4:09 
dnsmasq-dhcp: DHCPACK(br-int) 192.168.123.67 ce:39:ba:89:b4:09 da45c7199ed8

dnsmasq-dhcp: read /var/lib/hosts/optsdir/stvcluster1-opts
dnsmasq-dhcp: read /var/lib/hosts/hostsdir/stvcluster1-host
```