### PR TITLE
[OCPQE-18644] - use ipxe on hpe arm servers only when boot mode is pxe

### DIFF
--- a/images/fcos-bastion-image/root/usr/bin/prepare_host_for_boot
+++ b/images/fcos-bastion-image/root/usr/bin/prepare_host_for_boot
@@ -41,7 +41,7 @@ until ipmi_cmd power status | grep -i -q "Chassis Power is off"; do
   sleep 30
 done
 
-if [ "${ipxe_via_vmedia}" == "true" ]; then
+if [[ "${ipxe_via_vmedia}" == "true" ]] && [[ "${BOOT_MODE}" == "pxe" ]]; then
   log "The host requires an ipxe image to boot via vmedia in order to perform the pxe boot..."
   mount.vmedia.ipxe "${HOST}"
 fi


### PR DESCRIPTION
This PR fixes a bug with hpe ARM servers that would always mount and boot from the ipxe image regardless of the configured boot mode