### PR TITLE
Fix sysntax error on file

### DIFF
--- a/images/bind9/root/etc/bind/named.conf.options
+++ b/images/bind9/root/etc/bind/named.conf.options
@@ -32,7 +32,7 @@ options {
 	   cause your server to become part of large scale DNS amplification
 	   attacks. Implementing BCP38 within your network would greatly
 	   reduce such attack surface
-	*/
+	*/;
 	recursion yes;
 
 	managed-keys-directory "/var/named/dynamic";


### PR DESCRIPTION
The PR aims to fix bind service complaint  about below error
Jan 24 11:45:03 dhcp-1-235-248.arm.eng.rdu2.redhat.com bind9[179891]: 24-Jan-2024 11:45:03.334 /etc/bind/named.conf.options:36: missing ';' before 'recursion'
Jan 24 11:45:03 dhcp-1-235-248.arm.eng.rdu2.redhat.com bind9[179891]: 24-Jan-2024 11:45:03.335 loading configuration: failure
Jan 24 11:45:03 dhcp-1-235-248.arm.eng.rdu2.redhat.com bind9[179891]: 24-Jan-2024 11:45:03.335 exiting (due to fatal error)