### PR TITLE
OCPQE-19170: Add timer unit for registries cleanup

### DIFF
--- a/images/fcos-bastion-image/root/usr/bin/clean-registries.sh
+++ b/images/fcos-bastion-image/root/usr/bin/clean-registries.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -x
+
+mapfile -t services < <(systemctl list-units --type service | grep -i "registry@" | awk '{print $1}' | awk -F'[@.]' '{print $2}')
+for port in "${services[@]}"; do
+  disk_use=$(df /opt/registry-"${port}" --output='pcent' | grep -o '[0-9]*')
+  if [ "$disk_use" -gt 85 ]; then
+    rm -rf /opt/registry-"${port}"/data/docker/registry/v2/repositories/*
+    systemctl restart registry@"${port}".service
+  fi
+done
+
+exit 0
+

--- a/images/fcos-bastion-image/root/usr/bin/clean-registries.sh
+++ b/images/fcos-bastion-image/root/usr/bin/clean-registries.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -x
 
-mapfile -t services < <(systemctl list-units --type service | grep -i "registry@" | awk '{print $1}' | awk -F'[@.]' '{print $2}')
-for port in "${services[@]}"; do
+mapfile -t ports < <(systemctl list-units 'registry@*' --no-pager --quiet | awk -F'[@.]' '{print $2}')
+for port in "${ports[@]}"; do
   disk_use=$(df /opt/registry-"${port}" --output='pcent' | grep -o '[0-9]*')
   if [ "$disk_use" -gt 85 ]; then
     rm -rf /opt/registry-"${port}"/data/docker/registry/v2/repositories/*
@@ -11,4 +11,3 @@ for port in "${services[@]}"; do
 done
 
 exit 0
-

--- a/images/fcos-bastion-image/root/usr/lib/systemd/system-preset/98-bastion.preset
+++ b/images/fcos-bastion-image/root/usr/lib/systemd/system-preset/98-bastion.preset
@@ -9,3 +9,4 @@ enable tang.service
 enable nfs-server.service
 enable enable-registries.service
 enable fill-network-env.service
+enable clean-registries.service

--- a/images/fcos-bastion-image/root/usr/lib/systemd/system/clean-registries.service
+++ b/images/fcos-bastion-image/root/usr/lib/systemd/system/clean-registries.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Service to clean up mirrored container images cache
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/clean-registries.sh
+RemainAfterExit=no
+RestartSec=10
+Restart=on-failure

--- a/images/fcos-bastion-image/root/usr/lib/systemd/system/clean-registries.timer
+++ b/images/fcos-bastion-image/root/usr/lib/systemd/system/clean-registries.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=Timer to cleanup mirrored registries caches on boot
+[Timer]
+OnBootSec=5min
+OnCalendar=Mon,Thu *-*-* 03:00:00
+
+[Install]
+WantedBy=timers.target

--- a/images/fcos-bastion-image/root/usr/lib/systemd/system/clean-registries.timer
+++ b/images/fcos-bastion-image/root/usr/lib/systemd/system/clean-registries.timer
@@ -2,7 +2,7 @@
 Description=Timer to cleanup mirrored registries caches on boot
 [Timer]
 OnBootSec=5min
-OnCalendar=Mon,Thu *-*-* 03:00:00
+OnCalendar=*-*-* *:00:00
 
 [Install]
 WantedBy=timers.target


### PR DESCRIPTION
The purpose of this PR is to create a timer unit that loops over all the enabled registries@ template units and clean up the mirrored container images.