### PR TITLE
OCPQE-18374: Add systemd unit to bring ovs2brBR up

### DIFF
--- a/images/fcos-bastion-image/root/usr/bin/network-conn-up.sh
+++ b/images/fcos-bastion-image/root/usr/bin/network-conn-up.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -x
+
+nmcli connection up ovs2brBR
+nmcli connection show --active | grep -q 'ovs2brBR'
+if [ $? -eq 0 ]; then
+    echo "Connection established successfully."
+    exit 0
+else
+    echo "Failed to establish connection."
+    exit 1
+fi

--- a/images/fcos-bastion-image/root/usr/bin/network-conn-up.sh
+++ b/images/fcos-bastion-image/root/usr/bin/network-conn-up.sh
@@ -2,8 +2,8 @@
 set -x
 
 nmcli connection up ovs2brBR
-nmcli connection show --active | grep -q 'ovs2brBR'
-if [ $? -eq 0 ]; then
+conn_status=$(nmcli connection show --active | grep -q 'ovs2brBR' && echo "active" || echo "inactive")
+if [ "$conn_status" = "active" ]; then
     echo "Connection established successfully."
     exit 0
 else

--- a/images/fcos-bastion-image/root/usr/lib/systemd/system-preset/98-bastion.preset
+++ b/images/fcos-bastion-image/root/usr/lib/systemd/system-preset/98-bastion.preset
@@ -11,3 +11,4 @@ enable enable-registries.service
 enable fill-network-env.service
 enable nodes-pruner.timer
 enable clean-registries.service
+enable ovs2br-conn-bringup.service

--- a/images/fcos-bastion-image/root/usr/lib/systemd/system/ovs2br-conn-bringup.service
+++ b/images/fcos-bastion-image/root/usr/lib/systemd/system/ovs2br-conn-bringup.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Bring up ovs2brBR network connection and other non active connections
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/network-conn-up.sh
+RestartSec=30
+StartLimitBurst=10
+Restart=on-failure


### PR DESCRIPTION
testing done:

re@dhcp-1-235-143:~$ sudo systemctl status ovs2br-conn-bringup.service -l --no-pager
○ ovs2br-conn-bringup.service - Bring up ovs2brBR network connection and other non active connections
     Loaded: loaded (/usr/lib/systemd/system/ovs2br-conn-bringup.service; static)
    Drop-In: /usr/lib/systemd/system/service.d
             └─10-timeout-abort.conf
     Active: inactive (dead)

Feb 21 08:44:34 dhcp-1-235-143.arm.eng.rdu2.redhat.com network-conn-up.sh[1543]: + nmcli connection up testConnection
Feb 21 08:44:38 localhost.localdomain network-conn-up.sh[1544]: Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/3)
Feb 21 08:44:38 localhost.localdomain network-conn-up.sh[1586]: + nmcli connection show --active
Feb 21 08:44:38 localhost.localdomain network-conn-up.sh[1589]: + grep -q testConnection
Feb 21 08:44:38 localhost.localdomain network-conn-up.sh[1543]: + '[' 0 -eq 0 ']'
Feb 21 08:44:38 localhost.localdomain network-conn-up.sh[1543]: + echo 'Connection established successfully.'
Feb 21 08:44:38 localhost.localdomain network-conn-up.sh[1543]: Connection established successfully.
Feb 21 08:44:38 localhost.localdomain network-conn-up.sh[1543]: + exit 0
Feb 21 08:44:38 localhost.localdomain systemd[1]: ovs2br-conn-bringup.service: Deactivated successfully.
Feb 21 08:44:38 localhost.localdomain systemd[1]: Finished ovs2br-conn-bringup.service - Bring up ovs2brBR network connection and other non a


ournalctl -b -u ovs2br-conn-bringup.service -l --no--p
journalctl: unrecognized option '--no--p'
core@dhcp-1-235-143:~$ journalctl -b -u ovs2br-conn-bringup.service -l --no-pager
Feb 21 08:44:34 dhcp-1-235-143.arm.eng.rdu2.redhat.com systemd[1]: Starting ovs2br-conn-bringup.service - Bring up ovs2brBR network connection and other non active connections...
Feb 21 08:44:34 dhcp-1-235-143.arm.eng.rdu2.redhat.com network-conn-up.sh[1543]: + nmcli connection up testConnection
Feb 21 08:44:38 localhost.localdomain network-conn-up.sh[1544]: Connection successfully activated (D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/3)
Feb 21 08:44:38 localhost.localdomain network-conn-up.sh[1586]: + nmcli connection show --active
Feb 21 08:44:38 localhost.localdomain network-conn-up.sh[1589]: + grep -q testConnection
Feb 21 08:44:38 localhost.localdomain network-conn-up.sh[1543]: + '[' 0 -eq 0 ']'
Feb 21 08:44:38 localhost.localdomain network-conn-up.sh[1543]: + echo 'Connection established successfully.'
Feb 21 08:44:38 localhost.localdomain network-conn-up.sh[1543]: Connection established successfully.
Feb 21 08:44:38 localhost.localdomain network-conn-up.sh[1543]: + exit 0
Feb 21 08:44:38 localhost.localdomain systemd[1]: ovs2br-conn-bringup.service: Deactivated successfully.
Feb 21 08:44:38 localhost.localdomain systemd[1]: Finished ovs2br-conn-bringup.service - Bring up ovs2brBR network connection and other non active connections.


nmcli connection show  --active
NAME            UUID                                  TYPE      DEVICE
testConnection  063f0308-1000-4301-ae0e-0d578ac283fd  ethernet  enp1s0
lo              ad1a65c3-5c50-49ab-bc6e-2418c901f5df  loopback  lo
