### PR TITLE
Remove dhcp-boot, use dhcp option 67 (bootfile-name)

### DIFF
--- a/images/fcos-bastion-image/root/usr/share/bastion_services/dhcp/dnsmasq.conf
+++ b/images/fcos-bastion-image/root/usr/share/bastion_services/dhcp/dnsmasq.conf
@@ -24,8 +24,8 @@ tftp-root=/var/lib/tftpboot
 dhcp-match=set:efi,option:client-arch,7
 dhcp-match=set:efi,option:client-arch,9
 dhcp-match=set:efi_arm,option:client-arch,11
-dhcp-boot=tag:efi,grubx64.efi
-dhcp-boot=tag:efi_arm,grubaa64.efi
+dhcp-option=tag:efi,67,grubx64.efi
+dhcp-option=tag:efi_arm,67,grubaa64.efi
 
 dhcp-hostsdir=/var/lib/hosts/hostsdir
 dhcp-optsdir=/var/lib/hosts/optsdir


### PR DESCRIPTION
As dhcp-boot override, especially when used in dhcp-optsdir