### PR TITLE
Disable libvirt default network

### DIFF
--- a/images/fcos-base-image/root/usr/bin/libvirt_init.sh
+++ b/images/fcos-base-image/root/usr/bin/libvirt_init.sh
@@ -22,3 +22,4 @@ fi
 mkdir -p "${STORAGE_FOLDER}"
 virsh pool-autostart "${STORAGE_POOL_NAME}"
 virsh pool-info "${STORAGE_POOL_NAME}" | grep -iqE "State:[ ]+running" || virsh pool-start "${STORAGE_POOL_NAME}"
+virsh net-autostart --network default --disable


### PR DESCRIPTION
libvirt spawns its own dnsmasq instance listening at 192.168.122.1:53, since the port-forwarding on the bind9 container is set to all the IPs, if libvirt is initialized before bind9, bind9 can't start as can't bind to port *:53.