### PR TITLE
OCPQE-19722: Fix registry@.service healthchecks

### DIFF
--- a/images/fcos-bastion-image/root/usr/lib/systemd/system/registry@.service
+++ b/images/fcos-bastion-image/root/usr/lib/systemd/system/registry@.service
@@ -18,14 +18,18 @@ ExecStart=/usr/bin/podman run --name registry-${PORT} \
             -v /opt/registry-${PORT}/auth:/auth:Z \
             -v /opt/registry-${PORT}/certs:/certs:Z \
             -v /opt/registry-${PORT}/config.yaml:/etc/docker/registry/config.yml:Z \
-            --health-cmd="wget -q -O /dev/null --no-check-certificate https://localhost:${PORT}/ && \
-                          wget -q -O /dev/null --no-check-certificate https://${ext0_IPADDR}:${PORT}/ && \
-                          wget -q -O /dev/null --no-check-certificate https://${baremetal_IPADDR}:${PORT}/" \
+            --health-cmd="apk add curl; \
+                          curl -k -s -o /dev/null https://localhost:${PORT}/ && \
+                          curl -k -s -o /dev/null https://${ext0_IPADDR}:${PORT}/ && \
+                          curl -k -s -o /dev/null https://${baremetal_IPADDR}:${PORT}/" \
             --health-interval=10s \
             --health-retries=3 \
             --health-on-failure=kill \
             --env-file /opt/registry-${PORT}/env \
             quay.io/libpod/registry:2.8.2
+# curl is currently installed the first time the registry starts to avoid forking the image. The only binary included
+# that can support the healthcheck is the BusyBox's version of wget, and it seems affected by
+# https://github.com/distribution/distribution-library-image/issues/158
 ExecStop=/usr/bin/podman stop --ignore registry-${PORT}
 ExecStopPost=/usr/bin/podman rm -f --ignore registry-${PORT}
 Restart=always


### PR DESCRIPTION
The registry@ services become unhealthy and get killed after a while they started.

This is due to distribution/distribution-library-image#158. The healthchecks are based on wget, and wget leaks a defunct process everytime the healthcheck launches. Eventually, we reach the ulimit, no more forks are allowed and the container is restarted.

This commit changes the healtcheck to use curl, that is installed by the healthcheck itself if not already available. This is a workaround to revert once a fix for distribution/distribution-library-image#158 lands and a new image is published.