### PR TITLE
OCPQE-18644: Set BootSourceOverrideEnabled once

### DIFF
--- a/images/fcos-bastion-image/root/usr/bin/mount.vmedia.ipxe
+++ b/images/fcos-bastion-image/root/usr/bin/mount.vmedia.ipxe
@@ -10,29 +10,3 @@ host_id="${1}"
 host_obj=$(sed '1s/^#//; 2,${/^#/d; /^$/d}' "/etc/hosts_pool_inventory" | yq -p csv '.[] | select(.bmc_address == "*'"${host_id}"'*")')
 arch=$(echo "${host_obj}" | yq -r '.arch')
 mount.vmedia "${1}" "http://192.168.70.1/ipxe/ipxe.$arch.usb"
-
-vendor=$(echo "${host_obj}" | yq -r '.vendor')
-redfish_user=$(echo "${host_obj}" | yq -r '.redfish_user')
-redfish_password=$(echo "${host_obj}" | yq -r '.redfish_password')
-bmc_address=$(echo "${host_obj}" | yq -r '.bmc_address')
-case "${vendor}" in
-  dell)
-    curl -k -u "${redfish_user}:${redfish_password}" -X POST \
-      "https://$bmc_address/redfish/v1/Managers/iDRAC.Embedded.1/Actions/Oem/EID_674_Manager.ImportSystemConfiguration" \
-       -H "Content-Type: application/json" -d \
-       '{"ShareParameters":{"Target":"ALL"},"ImportBuffer":
-          "<SystemConfiguration><Component FQDD=\"iDRAC.Embedded.1\">
-          <Attribute Name=\"ServerBoot.1#BootOnce\">Enabled</Attribute>
-          <Attribute Name=\"ServerBoot.1#FirstBootDevice\">VCD-DVD</Attribute>
-          </Component></SystemConfiguration>"}'
-  ;;
-  hpe)
-    curl -k -u "${redfish_user}:${redfish_password}" -X PATCH \
-      "https://${bmc_address}/redfish/v1/Systems/1/" \
-      -H 'Content-Type: application/json' \
-      -d '{"Boot": {"BootSourceOverrideTarget": "Cd"}}'
-  ;;
-  *)
-    echo "Unsupported vendor ${vendor}"
-    exit 1
-esac

--- a/images/fcos-bastion-image/root/usr/bin/prepare_host_for_boot
+++ b/images/fcos-bastion-image/root/usr/bin/prepare_host_for_boot
@@ -70,7 +70,7 @@ case "${vendor}" in
     curl -k -u "${redfish_user}:${redfish_password}" -X PATCH \
       "https://$address/redfish/v1/Systems/1/" \
       -H 'Content-Type: application/json' \
-      -d '{"Boot": {"BootSourceOverrideTarget": "'"$boot_selection"'"}}'
+      -d '{"Boot": {"BootSourceOverrideTarget": "'"$boot_selection"'", "BootSourceOverrideEnabled": "Once"}}'
   ;;
   *)
     log "Unknown vendor ${vendor}"


### PR DESCRIPTION
For arm64 hpe hosts the vmedia does not seem to get ejected after the
first boot causing the hosts to boot via pxe on every boot and failing
install. This should set the pxe enabled via vmedia to be used only
once.

Remove setting of one-time boot from mount.vmedia.ipxe to keep it
specific to mounting while prepare_host_for_boot does this setting.