### PR TITLE
OCPQE-19171: Cleanup timer unit for the ipi cached ISO

### DIFF
--- a/images/fcos-base-image/root/usr/bin/cache-clean-ipi.sh
+++ b/images/fcos-base-image/root/usr/bin/cache-clean-ipi.sh
@@ -1,13 +1,12 @@
 #!/bin/bash
 set -x
 
-NOW=$(date +'%s')
+iso_path="/home/kni/.cache/openshift-installer/image_cache/"
 
-for f in /home/kni/.cache/openshift-installer/image_cache/*; do
-  ACCESS=$(stat --format=%X "$f")
-  DELTA=$((NOW - ACCESS))
-  # 15 days
-  if [ $DELTA -gt 1296000 ]; then
-    rm -f "$f"
-  fi
-done
+if [ -d "${iso_path}" ]; then
+  echo "<3>${iso_path} exists, cleaning up 15 days old unused ISO"
+  find "${iso_path}" -type "f,d" -atime +15 -delete
+else
+  echo "<2>${iso_path} directory does not exist"
+fi
+

--- a/images/fcos-base-image/root/usr/lib/systemd/system/cache-clean-ipi.service
+++ b/images/fcos-base-image/root/usr/lib/systemd/system/cache-clean-ipi.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Service does a clean up of cached iso not use for more than 15 days
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/cache-clean-ipi.sh
+StandardOutput=journal
+StandardError=journal
+Type=oneshot
+RestartSec=10
+Restart=on-failure
+
+

--- a/images/fcos-base-image/root/usr/lib/systemd/system/cache-clean-ipi.timer
+++ b/images/fcos-base-image/root/usr/lib/systemd/system/cache-clean-ipi.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=Timer to clean cached iso unused and older than 15 days
+
+[Timer]
+OnCalendar=*-*-* *:30:00/3
+
+[Install]
+WantedBy=timers.target

--- a/images/fcos-bastion-image/root/usr/bin/clean-up.sh
+++ b/images/fcos-bastion-image/root/usr/bin/clean-up.sh
@@ -19,6 +19,6 @@ done < <(find /var/builds/ -maxdepth 1 -type d -mtime +2 -print0)
 for port in $(ovs-vsctl show  | grep "No such device" | sed -e 's/^.*device //' -e 's/ (No such.*$//')
 do
   bridge=$(ovs-vsctl port-to-br "$port")
-  echo "Deleting orphan port $bridge/$port"
+  echo "<3>Deleting orphan port $bridge/$port"
   ovs-vsctl del-port "$bridge" "$port"
 done

--- a/images/fcos-bastion-image/root/usr/lib/systemd/system/nodes-pruner.timer
+++ b/images/fcos-bastion-image/root/usr/lib/systemd/system/nodes-pruner.timer
@@ -2,7 +2,7 @@
 Description=Timer to prune cluster nodes running longer than 3 days
 
 [Timer]
-OnCalendar=*-*-* *:0/2:0
+OnCalendar=*-*-* *:02:00
 
 [Install]
 WantedBy=timers.target


### PR DESCRIPTION
Timer is set to run 30 mins past the hour, every 3 hours to delete any
iso files not used for more than 15 days.

Additional updates
Nodes pruner was set to run every 2 mins. This PR updates to run 2 minutes past
every hour.
Include tag for color in logs
