### PR TITLE
OCPQE-23078: setup an expiry date for persistent clusters

### DIFF
--- a/images/fcos-bastion-image/root/usr/bin/clean-up.sh
+++ b/images/fcos-bastion-image/root/usr/bin/clean-up.sh
@@ -7,11 +7,33 @@ while IFS= read -r -d '' cluster_folder
 do
   echo "<3>Deleting $cluster_folder"
   cluster=$(basename "$cluster_folder")
-  if [ -f "$cluster_folder/preserve" ]; then
-    echo "<3>$cluster is marked to ignore the automatic pruning, skipping..."
+
+  # To preserve a cluster, create an empty file named 'preserve'
+  # To preserve a cluster with an expiry date, add the date in ISO 8601 (YYYY-MM-DD) and in UTC formate in preserve file
+  # eg. To preserve cluster for a week
+  # date --utc -I -d "1 week" > /var/builds/<cluster_name>/preserve
+  # Or with exact time
+  # date --utc -Iseconds -d "1 week 5:45 pm" > /var/builds/<cluster_name>/preserve
+  if [ -e "$cluster_folder/preserve" ] && [ ! -s "$cluster_folder/preserve" ]; then
+    echo "<3>$cluster is marked to ignore the automatic pruning forever, skipping..."
     continue
+  elif [ -s "$cluster_folder/preserve" ]; then
+    echo "<3>$cluster is marked to ignore the automatic pruning, checking the expiry date..."
+    nowdate=$(date +%s)
+    chkdate=$(date --utc -d "$(<"${cluster_folder}"/preserve)" -Iseconds 2>&1)
+    chkstatus=$?
+    if [ "${chkstatus}" -ne 0 ]; then
+      echo "<2>$cluster preserve time is not in ISO 8601 format, preparing to prune..."
+      enddate="${nowdate}"
+    else
+      enddate=$(date -d "${chkdate}" +%s)
+    fi
+    [ "${enddate}" -gt "${nowdate}" ] && \
+    echo "<3>$cluster to continue being preserved, skipping..." && continue
+    [ "${enddate}" -le "${nowdate}" ] && \
+    echo "<3>$cluster no longer to be preserved"
   fi
-  echo "<3>$cluster is more than 3 days old, starting the pruning...."
+  echo "<3>$cluster is more than 3 days old and not preserved, starting the pruning...."
   prune_nodes "$cluster"
 done < <(find /var/builds/ -maxdepth 1 -type d -mtime +2 -print0)
 


### PR DESCRIPTION
Enable setting an expiry date for persistent clusters in ISO 8601 and
UTC format, or keep the cluster persistent forever with an empty preseve
file