### PR TITLE
OCPQE-20708: Increase retrials and delay between health-checks for registry@

### DIFF
--- a/images/fcos-bastion-image/root/usr/lib/systemd/system/registry@.service
+++ b/images/fcos-bastion-image/root/usr/lib/systemd/system/registry@.service
@@ -18,12 +18,12 @@ ExecStart=/usr/bin/podman run --name registry-${PORT} \
             -v /opt/registry-${PORT}/auth:/auth:Z \
             -v /opt/registry-${PORT}/certs:/certs:Z \
             -v /opt/registry-${PORT}/config.yaml:/etc/docker/registry/config.yml:Z \
-            --health-cmd="apk add curl; \
+            --health-cmd="sleep 10s; apk add curl; \
                           curl -k -s -o /dev/null https://localhost:${PORT}/ && \
                           curl -k -s -o /dev/null https://${ext0_IPADDR}:${PORT}/ && \
                           curl -k -s -o /dev/null https://${baremetal_IPADDR}:${PORT}/" \
-            --health-interval=10s \
-            --health-retries=3 \
+            --health-interval=30s \
+            --health-retries=10 \
             --health-on-failure=kill \
             --env-file /opt/registry-${PORT}/env \
             quay.io/libpod/registry:2.8.2


### PR DESCRIPTION
This PR proposes to increase the delay between health-checks and adds further delay to avoid immediate re-execution on failure and allow temporary issues due to overload from letting podman considering the registry failed and restarting it.