### PR TITLE
OCPQE-25546: Add timer service to cleanup podman unused resources

### DIFF
--- a/images/fcos-bastion-image/root/usr/bin/clean-up.sh
+++ b/images/fcos-bastion-image/root/usr/bin/clean-up.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 echo "<3>Starting the clean up process"
-echo "<2>Checking if any /var/builds/* folder container is older than 3 days and prune the related clusters"
-# Check if any /var/builds/* folder container is older than 3 days
+echo "<2>Checking if any /var/builds/* folder container is older than 24 hours and prune the related clusters"
+# Check if any /var/builds/* folder container is older than 24 hours
 while IFS= read -r -d '' cluster_folder
 do
   echo "<3>Deleting $cluster_folder"
@@ -33,7 +33,7 @@ do
     [ "${enddate}" -le "${nowdate}" ] && \
     echo "<3>$cluster no longer to be preserved"
   fi
-  echo "<3>$cluster is more than 3 days old and not preserved, starting the pruning...."
+  echo "<3>$cluster is more than 24 hours old and not preserved, starting the pruning...."
   prune_nodes "$cluster"
 done < <(find /var/builds/ -maxdepth 1 -type d -mmin +1440 -print0)
 

--- a/images/fcos-bastion-image/root/usr/lib/systemd/system/nodes-pruner.service
+++ b/images/fcos-bastion-image/root/usr/lib/systemd/system/nodes-pruner.service
@@ -1,12 +1,11 @@
 [Unit]
-Description=Service does a clean up of clusters running more than 3 days
+Description=Service does a clean up of clusters running more than 24 hours
 
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/clean-up.sh
 StandardOutput=journal
 StandardError=journal
-Type=oneshot
 RestartSec=10
 Restart=on-failure
 

--- a/images/fcos-bastion-image/root/usr/lib/systemd/system/nodes-pruner.timer
+++ b/images/fcos-bastion-image/root/usr/lib/systemd/system/nodes-pruner.timer
@@ -1,5 +1,5 @@
 [Unit]
-Description=Timer to prune cluster nodes running longer than 3 days
+Description=Timer to prune cluster nodes running longer than 24 hour
 
 [Timer]
 OnCalendar=*-*-* *:02:00

--- a/images/fcos-bastion-image/root/usr/lib/systemd/system/podman-pruner.service
+++ b/images/fcos-bastion-image/root/usr/lib/systemd/system/podman-pruner.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Service does a clean up of unused podman resources
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/podman system prune -af --volumes
+StandardOutput=journal
+StandardError=journal
+RestartSec=10
+Restart=on-failure

--- a/images/fcos-bastion-image/root/usr/lib/systemd/system/podman-pruner.timer
+++ b/images/fcos-bastion-image/root/usr/lib/systemd/system/podman-pruner.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=Timer to daily prune unused podman resources
+
+[Timer]
+OnCalendar=*-*-* 06:00:00
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Timer will run daily at 6 am

PR also updates logs and comments for deleting clusters older than `24h` from previouly set `3 days`