### PR TITLE
Remove preserve file before calling prune_nodes

### DIFF
--- a/images/fcos-bastion-image/root/usr/bin/clean-up.sh
+++ b/images/fcos-bastion-image/root/usr/bin/clean-up.sh
@@ -32,6 +32,7 @@ do
     echo "<3>$cluster to continue being preserved, skipping..." && continue
     [ "${enddate}" -le "${nowdate}" ] && \
     echo "<3>$cluster no longer to be preserved"
+      rm -f "$cluster_folder/preserve"
   fi
   echo "<3>$cluster is more than 24 hours old and not preserved, starting the pruning...."
   prune_nodes "$cluster"


### PR DESCRIPTION
below scripys:
bash ./wipe/baremetal-lab-post-wipe-commands.sh
bash ./dns/baremetal-lab-post-dns-commands.sh
bash ./firewall/baremetal-lab-post-firewall-commands.sh
bash ./load-balancer/baremetal-lab-post-load-balancer-commands.sh

contains the following  code snippet:
[ -z “${PULL_NUMBER:-}” ] && \
  timeout -s 9 10m ssh “${SSHOPTS[@]}” “root@${AUX_HOST}” \
    test -f /var/builds/${NAMESPACE}/preserve && \
  exit 0
which causes them to exit 0 early, due to the existence of preserve file, hence actual pruning will not happen

The PR propose to delete preserve file once a decision is taken to prune the cluster, before calling prune_nodes

