### PR TITLE
OCPQE-28188: Check and clean up leftover dhcp entries

### DIFF
--- a/images/fcos-base-image/Containerfile
+++ b/images/fcos-base-image/Containerfile
@@ -12,15 +12,14 @@ RUN set -x; arch=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/'); cat /etc/
 # Also, installing nfs-utils will leave content in /var. `rm -rf /var/*` is a workaround until the packages are fixed.
 RUN rpm-ostree uninstall nfs-utils-coreos && rpm-ostree install nfs-utils && rm -rf /var/* && ostree container commit
 
-RUN set -x; PACKAGES_INSTALL="bridge-utils conntrack-tools curl fping iftop iputils iproute mtr nethogs socat chrony \
-                              targetcli net-tools bind-utils iperf iperf3 iputils mtr ethtool tftp wget ipmitool gawk \
-                              htop ncdu procps strace iotop subversion git git-lfs gnupg2 lldpd openssl openvpn rsync tcpdump  \
-                              nmap nmap-ncat krb5-workstation qemu-kvm qemu-user-static libvirt virt-manager virt-install lshw \
-                              sudo screen telnet unzip util-linux-user ignition  zsh nmap-ncat socat python3-pip man pciutils  \
+RUN set -x; PACKAGES_INSTALL="bridge-utils conntrack-tools curl fping iftop iputils iproute mtr nethogs socat chrony iperf \
+                              iperf3 iputils mtr ethtool tftp wget ipmitool gawk targetcli net-tools bind-utils htop ncdu \
+                              procps strace iotop subversion git git-lfs gnupg2 lldpd openssl openvpn rsync nmap nmap-ncat zsh \
+                              krb5-workstation qemu-kvm qemu-user-static libvirt virt-manager virt-install crypto-policies-scripts \
+                              sudo screen telnet unzip util-linux-user ignition lshw tcpdump socat python3-pip man pciutils  \
                               skopeo jq vim neovim inotify-tools firewall-config openvswitch NetworkManager-ovs tree sshpass"; \
     rpm-ostree install $PACKAGES_INSTALL \
-    && ln -s /usr/bin/ld.bfd /usr/bin/ld \
-    && ln -s /usr/sbin/ovs-vswitchd.dpdk /usr/sbin/ovs-vswitchd \
+    && ln -sf /usr/sbin/ovs-vswitchd.dpdk /usr/sbin/ovs-vswitchd \
     && rm -rf /var/* \
     && rpm-ostree cleanup -m \
     && ostree container commit
@@ -30,7 +29,7 @@ COPY root/ /
 RUN set -x; systemctl preset-all \
     && rpm-ostree ex rebuild \
     && rpm-ostree cleanup -m \
-    && ln -s /usr/bin/podman /usr/bin/docker \
+    && ln -sf /usr/bin/podman /usr/bin/docker \
     && echo "net.ipv4.ip_forward = 1" >> /etc/sysctl.d/99-sysctl.conf \
     && echo "net.ipv6.conf.all.forwarding = 1" >> /etc/sysctl.d/99-sysctl.conf \
     && echo "net.ipv4.ip_unprivileged_port_start = 1" >> /etc/sysctl.d/99-sysctl.conf \
@@ -60,5 +59,5 @@ RUN HOME=/tmp RUNZSH=no CHSH=no ZSH=/usr/lib/ohmyzsh \
 
 ARG TOOLBOX_IMAGE=quay.io/openshifttest/fedora:bm-auto-toolbox
 RUN set -x; update-crypto-policies --set legacy --no-reload \
- && echo "image = \"${TOOLBOX_IMAGE}\"" >> /etc/containers/toolbox.conf \
- && ostree container commit
+    && echo "image = \"${TOOLBOX_IMAGE}\"" >> /etc/containers/toolbox.conf \
+    && ostree container commit

--- a/images/fcos-bastion-image/root/usr/bin/clean-up.sh
+++ b/images/fcos-bastion-image/root/usr/bin/clean-up.sh
@@ -45,3 +45,10 @@ do
   echo "<3>Deleting orphan port $bridge/$port"
   ovs-vsctl del-port "$bridge" "$port"
 done
+
+# Check for leftover dhcp entries
+for cluster in $(find /opt/dnsmasq/hosts/ -type f -exec basename {} \; | sort | uniq); do
+  [ ! -d /var/builds/"$cluster" ] && \
+  echo "<3>$cluster directory does not exist, cleaning up leftover dhcp entries" && \
+  prune_nodes "$cluster"
+done

--- a/images/prow-image/root/usr/bin/deprovision.sh
+++ b/images/prow-image/root/usr/bin/deprovision.sh
@@ -19,6 +19,7 @@ SHARED_DIR="/var/builds/$1"
 ARTIFACT_DIR="/var/builds/$1"
 SELF_MANAGED_NETWORK="true"
 DISCONNECTED="true"
+INTERNAL_NET_CIDR="192.168.80.0/22"
 PROVISIONING_NET_DEV="prov" # Remove this variable after https://github.com/openshift/release/pull/46960 is merged
 # End (exported) environment variables setup
 set +a


### PR DESCRIPTION
Many cluster installs failed recently as 3-4 host had dhcp entries for a
non existing cluster. This PR will check for such occurrence and do a
cleanup.

Add INTERNAL_NET_CIDR for prune_nodes
This is needed for clean up of disconnected jobs