### PR TITLE
nfs-utils and nfs-utils-coreos conflict resolved in f44

### DIFF
--- a/images/fcos-base-image/Containerfile
+++ b/images/fcos-base-image/Containerfile
@@ -8,10 +8,6 @@ RUN set -x; arch=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/'); cat /etc/
         #https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm \
     && ostree container commit
 
-# Replacing nfs-utils-coreos with nfs-utils as some required packages (e.g., libvirt) depend on it: see coreos/fedora-coreos-tracker#572
-# Also, installing nfs-utils will leave content in /var. `rm -rf /var/*` is a workaround until the packages are fixed.
-RUN rpm-ostree install nfs-utils && rm -rf /var/* && ostree container commit
-
 RUN set -x; PACKAGES_INSTALL="bridge-utils conntrack-tools curl fping iftop iputils iproute mtr nethogs socat chrony iperf \
                               iperf3 iputils mtr ethtool tftp wget ipmitool gawk targetcli net-tools bind-utils htop ncdu \
                               procps strace iotop subversion git git-lfs gnupg2 lldpd openssl openvpn rsync nmap nmap-ncat zsh \


### PR DESCRIPTION
nfs-utils-coreos is now available in f44 as nfs-client-utils and does not conflict anymore. Removing the workaround.