### PR TITLE
Add SELinux policy for virtproxyd SSH access in FCOS 44

### DIFF
--- a/images/fcos-base-image/Containerfile
+++ b/images/fcos-base-image/Containerfile
@@ -23,6 +23,15 @@ RUN set -x; PACKAGES_INSTALL="bridge-utils conntrack-tools curl fping iftop iput
 
 COPY root/ /
 
+# After image update from fcos 43 to 44 we need custom selinux polices for
+# libvirt to avoid avc denials
+RUN set -x; cd /usr/share/selinux/local \
+    && checkmodule -M -m -o virtproxyd-complete.mod virtproxyd-complete.te \
+    && semodule_package -o virtproxyd-complete.pp -m virtproxyd-complete.mod \
+    && semodule -i virtproxyd-complete.pp \
+    && rm -f virtproxyd-complete.mod \
+    && ostree container commit
+
 RUN set -x; systemctl preset-all \
     && rpm-ostree ex rebuild \
     && rpm-ostree cleanup -m \

--- a/images/fcos-base-image/root/usr/share/selinux/local/virtproxyd-complete.te
+++ b/images/fcos-base-image/root/usr/share/selinux/local/virtproxyd-complete.te
@@ -1,0 +1,12 @@
+module virtproxyd-complete 1.0;
+
+require {
+    type virtproxyd_t;
+    type sshd_session_t;
+    class dir search;
+    class file { open read };
+}
+
+#============= virtproxyd_t ==============
+allow virtproxyd_t sshd_session_t:dir search;
+allow virtproxyd_t sshd_session_t:file { open read };


### PR DESCRIPTION
After upgrading the base image to Fedora CoreOS 44 (PR #115), libvirt connections over SSH (qemu+ssh://) were failing due to SELinux AVC denials with permissive=0.

The denials prevented virtproxyd from accessing SSH session information in /proc, blocking operations like bootstrap VM creation and remote libvirt management.

This change adds a custom SELinux policy module (virtproxyd-complete) that allows virtproxyd_t to:
- Search sshd_session_t directories
- Read and open sshd_session_t files (/proc/PID/stat)

The policy is compiled and installed during the image build process.

Fixes: SELinux denials blocking qemu+ssh:// libvirt connections